### PR TITLE
Fix Windows zip name

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,7 +43,8 @@ deploy_x64:
   rules:
     !reference [.manual]
   script:
-    - Invoke-Expression "aws s3 cp --only-show-errors --region us-east-1 --sse AES256 --acl public-read build-out/python-windows-2.7.18-x64.zip s3://dd-agent-omnibus/test-python-windows-2.7.18-x64.zip"
+    - $hash_or_tag = git describe --exact-match --tags 2> /dev/null || git rev-parse --short HEAD
+    - Invoke-Expression "aws s3 cp --only-show-errors --region us-east-1 --sse AES256 --acl public-read build-out/python-windows-2.7.18-x64.zip s3://dd-agent-omnibus/python-windows-2.7.18-${$hash_or_tag}-x64.zip"
 
 deploy_x86:
   stage: deploy
@@ -52,4 +53,5 @@ deploy_x86:
   rules:
     !reference [.manual]
   script:
-    - Invoke-Expression "aws s3 cp --only-show-errors --region us-east-1 --sse AES256 --acl public-read build-out/python-windows-2.7.18-x86.zip s3://dd-agent-omnibus/test-python-windows-2.7.18-x86.zip"
+  - $hash_or_tag = git describe --exact-match --tags 2> /dev/null || git rev-parse --short HEAD
+    - Invoke-Expression "aws s3 cp --only-show-errors --region us-east-1 --sse AES256 --acl public-read build-out/python-windows-2.7.18-x86.zip s3://dd-agent-omnibus/python-windows-2.7.18-${$hash_or_tag}-x86.zip"


### PR DESCRIPTION
This PR removes the 'test' prefix from the zip name and adds a commit hash/tag suffix when pushing the artefacts to S3