### PR TITLE
build and ship as 3.8.11, not 3.8.10

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,11 +20,11 @@ variables:
     - if (Test-Path build-out) { remove-item -recurse -force build-out }
     - docker run --rm -v "$(Get-Location):c:\mnt" -e CI_JOB_ID=${CI_JOB_ID} -e WINDOWS_BUILDER=true -e AWS_NETWORKING=true -e TARGET_ARCH="$ARCH" 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_1809_${ARCH}:${Env:DATADOG_AGENT_WINBUILDIMAGES} C:\mnt\build.bat
     - get-childitem build-out
-    - Get-FileHash -Algorithm SHA256 build-out/python-windows-3.8.10-${ARCH}.zip
+    - Get-FileHash -Algorithm SHA256 build-out/python-windows-3.8.11-${ARCH}.zip
   artifacts:
     expire_in: 2 weeks
     paths:
-      - build-out/python-windows-3.8.10-${ARCH}.zip
+      - build-out/python-windows-3.8.11-${ARCH}.zip
 
 build_binaries_x64:
   extends: .build_common
@@ -45,8 +45,8 @@ deploy_x64:
   script:
     - $hash_or_tag = (git describe --exact-match --tags 2> $null)
     - if ($hash_or_tag -eq $null -or $hash_or_tag -eq ""){$hash_or_tag=git rev-parse --short HEAD}
-    - Write-Host "Uploading zip python-windows-3.8.10-${hash_or_tag}-x64.zip"
-    - Invoke-Expression "aws s3 cp --only-show-errors --region us-east-1 --sse AES256 --acl public-read build-out/python-windows-3.8.10-x64.zip s3://dd-agent-omnibus/python-windows-3.8.10-${hash_or_tag}-x64.zip"
+    - Write-Host "Uploading zip python-windows-3.8.11-${hash_or_tag}-x64.zip"
+    - Invoke-Expression "aws s3 cp --only-show-errors --region us-east-1 --sse AES256 --acl public-read build-out/python-windows-3.8.11-x64.zip s3://dd-agent-omnibus/python-windows-3.8.11-${hash_or_tag}-x64.zip"
 
 deploy_x86:
   stage: deploy
@@ -57,5 +57,5 @@ deploy_x86:
   script:
     - $hash_or_tag = (git describe --exact-match --tags 2> $null)
     - if ($hash_or_tag -eq $null -or $hash_or_tag -eq ""){$hash_or_tag=git rev-parse --short HEAD}
-    - Write-Host "Uploading zip python-windows-3.8.10-${hash_or_tag}-x86.zip"
-    - Invoke-Expression "aws s3 cp --only-show-errors --region us-east-1 --sse AES256 --acl public-read build-out/python-windows-3.8.10-x86.zip s3://dd-agent-omnibus/python-windows-3.8.10-${hash_or_tag}-x86.zip"
+    - Write-Host "Uploading zip python-windows-3.8.11-${hash_or_tag}-x86.zip"
+    - Invoke-Expression "aws s3 cp --only-show-errors --region us-east-1 --sse AES256 --acl public-read build-out/python-windows-3.8.11-x86.zip s3://dd-agent-omnibus/python-windows-3.8.11-${hash_or_tag}-x86.zip"


### PR DESCRIPTION
This was missed in the previous PR, and the resulting build/deploy jobs just built/deployed 3.8.10.