### PR TITLE
upgrade openssl to 1.1.1w

### DIFF
--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -53,7 +53,7 @@ echo.Fetching external libraries...
 set libraries=
 set libraries=%libraries%                                       bzip2-1.0.8
 if NOT "%IncludeLibffiSrc%"=="false" set libraries=%libraries%  libffi-3.3.0
-if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-1.1.1u
+if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-1.1.1w
 set libraries=%libraries%                                       sqlite-3.37.2.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tcl-core-8.6.12.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tk-8.6.12.0
@@ -77,7 +77,7 @@ echo.Fetching external binaries...
 
 set binaries=
 if NOT "%IncludeLibffi%"=="false"  set binaries=%binaries% libffi-3.3.0
-if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-1.1.1u
+if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-1.1.1w
 if NOT "%IncludeTkinter%"=="false" set binaries=%binaries% tcltk-8.6.12.0
 if NOT "%IncludeSSLSrc%"=="false"  set binaries=%binaries% nasm-2.11.06
 

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -68,8 +68,8 @@
     <libffiDir Condition="$(libffiDir) == ''">$(ExternalsDir)libffi-3.3.0\</libffiDir>
     <libffiOutDir Condition="$(libffiOutDir) == ''">$(libffiDir)$(ArchName)\</libffiOutDir>
     <libffiIncludeDir Condition="$(libffiIncludeDir) == ''">$(libffiOutDir)include</libffiIncludeDir>
-    <opensslDir Condition="$(opensslDir) == ''">$(ExternalsDir)openssl-1.1.1u\</opensslDir>
-    <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-1.1.1u\$(ArchName)\</opensslOutDir>
+    <opensslDir Condition="$(opensslDir) == ''">$(ExternalsDir)openssl-1.1.1w\</opensslDir>
+    <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-1.1.1w\$(ArchName)\</opensslOutDir>
     <opensslIncludeDir Condition="$(opensslIncludeDir) == ''">$(opensslOutDir)include</opensslIncludeDir>
     <nasmDir Condition="$(nasmDir) == ''">$(ExternalsDir)\nasm-2.11.06\</nasmDir>
     <zlibDir Condition="$(zlibDir) == ''">$(ExternalsDir)\zlib-1.2.12\</zlibDir>

--- a/Tools/ssl/multissltests.py
+++ b/Tools/ssl/multissltests.py
@@ -49,7 +49,7 @@ OPENSSL_OLD_VERSIONS = [
 ]
 
 OPENSSL_RECENT_VERSIONS = [
-    "1.1.1u",
+    "1.1.1w",
     "3.0.2"
 ]
 


### PR DESCRIPTION
This PR upgrades openssl to 1.1.1w. Fixes CVE-2023-3017.